### PR TITLE
Debug instance for IntervalTree

### DIFF
--- a/src/tree/interval.rs
+++ b/src/tree/interval.rs
@@ -1,5 +1,6 @@
 use crate::util::Interval;
 use std::cmp::Ord;
+use std::fmt::Debug;
 use std::ops::Bound;
 use std::ops::Bound::*;
 use std::rc::Rc;
@@ -885,6 +886,13 @@ impl<T: Ord> IntervalTree<T> {
     }
 }
 
+impl<T: Debug + Ord> Debug for IntervalTree<T> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.write_str("IntervalTree ")?;
+        fmt.debug_set().entries(self.intervals().iter()).finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1371,5 +1379,14 @@ mod tests {
         }
 
         assert_eq!(result, accept);
+    }
+
+    #[test]
+    fn tree_interval_debug() {
+        let mut interval_tree = IntervalTree::<usize>::init();
+        assert_eq!(format!("{:?}", &interval_tree), "IntervalTree {}");
+        interval_tree.insert(Interval::new(Excluded(0), Included(1)));
+        assert_eq!(format!("{:?}", &interval_tree),
+            "IntervalTree {Interval { low: Excluded(0), high: Included(1) }}");
     }
 }

--- a/src/util/interval.rs
+++ b/src/util/interval.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 ///
 /// // initialize interval [2,4]
 /// let interval1 = Interval::new(Included(2), Included(4));
-/// 
+///
 /// // initialize interval [2,4)
 /// let interval2 = Interval::new(Included(2), Excluded(4));
 ///
@@ -37,6 +37,7 @@ use std::rc::Rc;
 /// // get overlapped interval between two intervals
 /// assert!(Interval::get_overlap(&interval1, &interval2).unwrap() == interval2);
 /// ```
+#[derive(Debug)]
 pub struct Interval<T: Ord> {
     low: Rc<Bound<T>>,
     high: Rc<Bound<T>>,


### PR DESCRIPTION
I love this crate, thanks for you work on it!

I've been using the IntervalTree struct in a project, and I've found it a bit frustrating that there's no Debug instance, since I can't easily add one myself without using a newtype.

Figured I'd hack together a quick PR to add it. Let me know if you'd like to see changes!