### PR TITLE
Hash instances for intervals and interval trees

### DIFF
--- a/src/tree/interval.rs
+++ b/src/tree/interval.rs
@@ -5,6 +5,7 @@ use std::ops::Bound;
 use std::ops::Bound::*;
 use std::rc::Rc;
 
+#[derive(Hash)]
 struct Node<T: Ord> {
     interval: Option<Interval<T>>,
     max: Option<Rc<Bound<T>>>,
@@ -175,6 +176,7 @@ impl<T: Ord> Node<T> {
 /// // intervals are: (15,23), [16,21), [17,19), (19,20]
 /// let intervals = interval_tree.intervals_between(&low, &high);
 /// ```
+#[derive(Hash)]
 pub struct IntervalTree<T: Ord> {
     root: Option<Box<Node<T>>>,
 }

--- a/src/util/interval.rs
+++ b/src/util/interval.rs
@@ -37,7 +37,7 @@ use std::rc::Rc;
 /// // get overlapped interval between two intervals
 /// assert!(Interval::get_overlap(&interval1, &interval2).unwrap() == interval2);
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Hash)]
 pub struct Interval<T: Ord> {
     low: Rc<Bound<T>>,
     high: Rc<Bound<T>>,


### PR DESCRIPTION
Another minor tweak PR,  that allows users to store intervals and interval trees as keys in hash maps.